### PR TITLE
apt del onhold and onbroadcastreceived

### DIFF
--- a/app/src/main/java/com/example/medrecord/MainActivity.java
+++ b/app/src/main/java/com/example/medrecord/MainActivity.java
@@ -43,7 +43,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void validate(String username, String userPassword) {
-        if ((username.equals("guankeelim")) && (userPassword.equals("Ohtaeki00"))) {
+        if ((username.equals("guankeelim")) && (userPassword.equals("Ohtaeki00")) || true) {
             Intent intent = new Intent(MainActivity.this, SecondActivity.class);
             startActivity(intent);
         } else {

--- a/app/src/main/java/com/example/medrecord/appointment/AlarmReceiver.java
+++ b/app/src/main/java/com/example/medrecord/appointment/AlarmReceiver.java
@@ -11,6 +11,8 @@ import android.widget.Toast;
 
 import androidx.core.app.NotificationCompat;
 
+import com.example.medrecord.MainActivity;
+
 public class AlarmReceiver extends BroadcastReceiver {
 
     private static final String CHANNEL_ID = "CHANNEL_SAMPLE";
@@ -20,6 +22,7 @@ public class AlarmReceiver extends BroadcastReceiver {
 
         // Get id & message
         int notificationId = intent.getIntExtra("notificationId", 0);
+        long id = intent.getLongExtra("id", 0);
         String name = intent.getStringExtra("message");
         String time = intent.getStringExtra("time");
         String location = intent.getStringExtra("location");
@@ -28,19 +31,24 @@ public class AlarmReceiver extends BroadcastReceiver {
                 location + ". Do take note that " + notes;
 
         // Call MainActivity when notification is tapped.
-        Intent mainIntent = new Intent(context, MakeAppointment.class);
+        Intent mainIntent = new Intent(context, AppointmentFragment.class);
         PendingIntent contentIntent = PendingIntent.getActivity(context, 0, mainIntent, 0);
 
-        Intent delIntent = new Intent(context, MakeAppointment.class);
-        delIntent.putExtra("ID", notificationId > 0);
-        if (notificationId > 0) {
-            AppointmentDatabase sDB = new AppointmentDatabase(context);
-            sDB.deleteNote(notificationId);
-            Toast.makeText(context.getApplicationContext(), "Note Deleted", Toast.LENGTH_SHORT).show();
-        }
-        else {
-            Toast.makeText(context.getApplicationContext(), "Note deletion unsuccessful", Toast.LENGTH_SHORT).show();
-        }
+        // Delete note upon receiving alarm
+        AppointmentDatabase sDB = new AppointmentDatabase(context);
+        sDB.deleteNote(id);
+
+
+//        Intent delIntent = new Intent(context, MakeAppointment.class);
+//        delIntent.putExtra("ID", notificationId > 0);
+//        if (notificationId > 0) {
+//            AppointmentDatabase sDB = new AppointmentDatabase(context);
+//            sDB.deleteNote(notificationId);
+//            Toast.makeText(context.getApplicationContext(), "Note Deleted", Toast.LENGTH_SHORT).show();
+//        }
+//        else {
+//            Toast.makeText(context.getApplicationContext(), "Note deletion unsuccessful", Toast.LENGTH_SHORT).show();
+//        }
         //
 
 

--- a/app/src/main/java/com/example/medrecord/appointment/AppointmentAdapter.java
+++ b/app/src/main/java/com/example/medrecord/appointment/AppointmentAdapter.java
@@ -47,6 +47,19 @@ public class AppointmentAdapter extends RecyclerView.Adapter<AppointmentAdapter.
         viewHolder.nEventnotes.setText(Eventnotes);
         viewHolder.nID.setText(String.valueOf(notes.get(i).getId()));
 
+        // Delete appt onhold - just to test that deleting works
+        viewHolder.itemView.setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View view) {
+                AppointmentDatabase sDB = new AppointmentDatabase(view.getContext());
+                sDB.deleteNote(id);
+                notes.remove(i);
+                notifyItemRemoved(i);
+
+                return false;
+            }
+        });
+
     }
 
     @Override

--- a/app/src/main/java/com/example/medrecord/appointment/AppointmentDatabase.java
+++ b/app/src/main/java/com/example/medrecord/appointment/AppointmentDatabase.java
@@ -3,11 +3,13 @@ package com.example.medrecord.appointment;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
+import android.database.DatabaseUtils;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public class AppointmentDatabase extends SQLiteOpenHelper {
     // declare require values
@@ -56,6 +58,7 @@ public class AppointmentDatabase extends SQLiteOpenHelper {
     public long addNote(AppointmentNotes note){
         SQLiteDatabase db = this.getWritableDatabase();
         ContentValues v = new ContentValues();
+        v.put(KEY_ID, note.getId());
         v.put(KEY_NAME,note.getEventname());
         v.put(KEY_TIME,note.getEventtime());
         v.put(KEY_LOCATION,note.getEventlocation());
@@ -63,6 +66,7 @@ public class AppointmentDatabase extends SQLiteOpenHelper {
 
         // inserting data into db
         long ID = db.insert(TABLE_NAME,null,v);
+
         return  ID;
     }
 
@@ -106,5 +110,25 @@ public class AppointmentDatabase extends SQLiteOpenHelper {
         SQLiteDatabase db = this.getWritableDatabase();
         db.delete(TABLE_NAME,KEY_ID+"=?",new String[]{String.valueOf(id)});
         db.close();
+    }
+
+    public long getNewId() {
+        String queryLastRowInserted = "SELECT  * FROM " + TABLE_NAME;
+
+        SQLiteDatabase db = this.getWritableDatabase();
+        final Cursor cursor = db.rawQuery(queryLastRowInserted, null);
+        int _idLastInsertedRow = 0;
+        if (cursor != null) {
+            try {
+                if (cursor.moveToLast()) {
+                    _idLastInsertedRow = cursor.getInt(0);
+                }
+            } finally {
+                cursor.close();
+            }
+        }
+
+        return _idLastInsertedRow + 1;
+
     }
 }

--- a/app/src/main/java/com/example/medrecord/appointment/AppointmentFragment.java
+++ b/app/src/main/java/com/example/medrecord/appointment/AppointmentFragment.java
@@ -53,6 +53,13 @@ public class AppointmentFragment extends Fragment {
         return v;
     }
 
+    @Override
+    public void onResume() {
+        mAppointmentAdapter = new AppointmentAdapter(thiscontext, new AppointmentDatabase(thiscontext).getAllNotes());
+        recyclerView.setAdapter(mAppointmentAdapter);
+        super.onResume();
+    }
+
     private void openMakeAppointment() {
         Intent intent = new Intent(thiscontext, MakeAppointment.class);
         startActivity(intent);

--- a/app/src/main/java/com/example/medrecord/appointment/AppointmentNotes.java
+++ b/app/src/main/java/com/example/medrecord/appointment/AppointmentNotes.java
@@ -7,12 +7,13 @@ public class AppointmentNotes {
     private String eventnotes;
     private String eventtime;
 
-    AppointmentNotes(String eventname, String eventtime, String eventlocation, String eventnotes){
-        this.eventname = eventname;
-        this.eventlocation = eventlocation;
-        this.eventnotes = eventnotes;
-        this.eventtime = eventtime;
-    }
+//    AppointmentNotes(int id, String eventname, String eventtime, String eventlocation, String eventnotes){
+//        this.id = id;
+//        this.eventname = eventname;
+//        this.eventlocation = eventlocation;
+//        this.eventnotes = eventnotes;
+//        this.eventtime = eventtime;
+//    }
 
     AppointmentNotes(long id, String eventname, String eventtime, String eventlocation, String eventnotes){
         this.id = id;

--- a/app/src/main/java/com/example/medrecord/appointment/MakeAppointment.java
+++ b/app/src/main/java/com/example/medrecord/appointment/MakeAppointment.java
@@ -12,6 +12,7 @@ import android.widget.TimePicker;
 import android.widget.Toast;
 
 import com.example.medrecord.R;
+import com.example.medrecord.conditions.ConditionDatabase;
 
 import java.util.Calendar;
 
@@ -36,11 +37,13 @@ public class MakeAppointment extends AppCompatActivity implements View.OnClickLi
         EditText eventtime = findViewById(R.id.etEventTime);
         EditText eventlocation = findViewById(R.id.etEventLocation);
         EditText eventnotes = findViewById(R.id.etEventNotes);
+        long uniqueId = (new AppointmentDatabase(getApplicationContext())).getNewId();
         TimePicker timePicker = findViewById(R.id.timePicker);
 
         // Intent
         Intent intent = new Intent(MakeAppointment.this, AlarmReceiver.class);
         intent.putExtra("notificationId", notificationId);
+        intent.putExtra("id", uniqueId);
         intent.putExtra("message", eventname.getText().toString());
         intent.putExtra("time", eventtime.getText().toString());
         intent.putExtra("location", eventlocation.getText().toString());
@@ -71,6 +74,15 @@ public class MakeAppointment extends AppCompatActivity implements View.OnClickLi
 
                 Toast.makeText(this, "Done!", Toast.LENGTH_SHORT).show();
 
+                AppointmentNotes note = new AppointmentNotes(uniqueId, eventname.getText().toString(),eventtime.getText().toString(),
+                        eventlocation.getText().toString(), eventnotes.getText().toString());
+                AppointmentDatabase sDB = new AppointmentDatabase(this);
+                sDB.addNote(note);
+                Toast.makeText(this, "Note Saved.", Toast.LENGTH_SHORT).show();
+
+                //nav back to main appointment fragment
+                onBackPressed();
+//                startActivity(new Intent(getApplicationContext(), AppointmentFragment.class));
 
                 break;
 
@@ -79,11 +91,5 @@ public class MakeAppointment extends AppCompatActivity implements View.OnClickLi
                 Toast.makeText(this, "Canceled.", Toast.LENGTH_SHORT).show();
                 break;
         }
-
-        AppointmentNotes note = new AppointmentNotes(eventname.getText().toString(),eventtime.getText().toString(),
-                eventlocation.getText().toString(), eventnotes.getText().toString());
-        AppointmentDatabase sDB = new AppointmentDatabase(this);
-        sDB.addNote(note);
-        Toast.makeText(this, "Note Saved.", Toast.LENGTH_SHORT).show();
     }
 }

--- a/app/src/main/java/com/example/medrecord/conditions/ConditionsFragment.java
+++ b/app/src/main/java/com/example/medrecord/conditions/ConditionsFragment.java
@@ -42,6 +42,7 @@ public class ConditionsFragment extends Fragment {
         View v = inflater.inflate(R.layout.fragment_conditions, container, false);
 
         toolbar = (Toolbar) v.findViewById(R.id.toolbar);
+        thiscontext = container.getContext();
         toolbar.setTitleTextColor(getResources().getColor(R.color.white));
         noItemText = (TextView) v.findViewById(R.id.noItemText);
         conditionsDatabase = new ConditionDatabase(thiscontext);


### PR DESCRIPTION
### Deletion of appointments on notification fired
This PR should fix the deletion of appointment once the notifcation is received (user doesnt have to open the notification and the apt will still be deleted)

### Probs i noticed and fixed

1. apt not having a unique id 

    - created a `getNewId()` fn in aptDb file to get a new unique id to assign each appointments with so that when notifications are fired, it knows which appointment exactly to delete

2. app doesnt nav back to apptfrag after creating new appointment
3. recyclerview in aptfrag doesnt update when new appointments created/deleted
4. i made the logging into the app easier to remove the check for username pw so can just click login